### PR TITLE
Activate PurgeCSS in Tailwind Config

### DIFF
--- a/postcss-config/tailwind.config.js
+++ b/postcss-config/tailwind.config.js
@@ -5,7 +5,7 @@ module.exports = {
     removeDeprecatedGapUtilities: true,
     purgeLayersByDefault: true,
   },
-  purge: [],
+  purge: ['./src/**/*.js'],
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
Activates PurgeCSS for production builds of the site by adding a glob to the purge array in `tailwind.config.js`

Currently only looks for `./src/**/*.js` (any JS file in the src directory). 

Reduces file size from 4.3 mb to 21kb